### PR TITLE
fixed 'since' parameter in GetRecentTradesAsync

### DIFF
--- a/Kraken.Net/KrakenClient.cs
+++ b/Kraken.Net/KrakenClient.cs
@@ -235,7 +235,7 @@ namespace Kraken.Net
             {
                 {"pair", symbol},
             };
-            parameters.AddOptionalParameter("since", since.HasValue ? JsonConvert.SerializeObject(since, new TimestampSecondsConverter()) : null);
+            parameters.AddOptionalParameter("since", since.HasValue ? JsonConvert.SerializeObject(since, new TimestampNanoSecondsConverter()) : null);
             return await Execute<KrakenTradesResult>(GetUri("/0/public/Trades"), HttpMethod.Get, ct, parameters: parameters).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
'since' parameter in GetRecentTradesAsync is now using TimestampNanoSecondsConverter
#11 