### PR TITLE
Changed 'closedtm' to 'closetm'

### DIFF
--- a/Kraken.Net/Objects/KrakenOrder.cs
+++ b/Kraken.Net/Objects/KrakenOrder.cs
@@ -45,7 +45,7 @@ namespace Kraken.Net.Objects
         /// <summary>
         /// Close timestamp
         /// </summary>
-        [JsonProperty("closedtm"), JsonConverter(typeof(TimestampSecondsConverter))]
+        [JsonProperty("closetm"), JsonConverter(typeof(TimestampSecondsConverter))]
         public DateTime? ClosedTime { get; set; }
 
         /// <summary>


### PR DESCRIPTION
According to the Kraken API documentation, the json key for ClosedTime should be 'closetm' and not 'closedtm'

![grafik](https://user-images.githubusercontent.com/9402008/91548863-5dcd8300-e926-11ea-8a87-2930b4919750.png)
