### PR TITLE
Adding string literals to the Orderbooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ bld/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/
+.vscode/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 

--- a/Kraken.Net.UnitTests/ConvertersTests/StreamOrderbookConvertersTest.cs
+++ b/Kraken.Net.UnitTests/ConvertersTests/StreamOrderbookConvertersTest.cs
@@ -1,0 +1,66 @@
+using System.Linq;
+using Kraken.Net.Converters;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace Kraken.Net.UnitTests.ConvertersTests.StreamOrderbookConvertersTests
+{
+    [TestFixture]
+    public class StreamOrderbookConvertersTests
+    {
+        private JArray fiveElements;
+
+        [OneTimeSetUp]
+        public void SetupData()
+        {
+            var fiveElementsString = @"
+            [
+                1234,
+                {
+                    ""a"": [
+                    [
+                        ""5541.30000"",
+                        ""2.50700000"",
+                        ""1534614248.456738""
+                    ],
+                    [
+                        ""5542.50000"",
+                        ""0.40100000"",
+                        ""1534614248.456738""
+                    ]
+                    ]
+                },
+                {
+                    ""b"": [
+                    [
+                        ""5541.30000"",
+                        ""0.00000000"",
+                        ""1534614335.345903""
+                    ]
+                    ],
+                    ""c"": ""974942666""
+                },
+                ""book-10"",
+                ""XBT/USD""
+                ]
+            ";
+
+            this.fiveElements = JArray.Parse(fiveElementsString);
+        }
+
+        [Test]
+        public void Event_Should_ParseCountOfFour()
+        {
+            var testObj = StreamOrderBookConverter.Convert(this.fiveElements);
+
+            Assert.AreEqual(2, testObj.Data.Asks.Count());
+            Assert.AreEqual(1, testObj.Data.Bids.Count());
+            Assert.AreEqual(1234, testObj.ChannelId);
+            Assert.AreEqual("book-10", testObj.Topic);
+            Assert.AreEqual("XBT/USD", testObj.Symbol);
+
+            Assert.AreEqual("0.40100000", testObj.Data.Asks.ElementAt(1).QuantityLiteral);
+            Assert.AreEqual("5542.50000", testObj.Data.Asks.ElementAt(1).PriceLiteral);
+        }
+    }
+}

--- a/Kraken.Net.UnitTests/ConvertersTests/StreamOrderbookConvertersTest.cs
+++ b/Kraken.Net.UnitTests/ConvertersTests/StreamOrderbookConvertersTest.cs
@@ -59,8 +59,8 @@ namespace Kraken.Net.UnitTests.ConvertersTests.StreamOrderbookConvertersTests
             Assert.AreEqual("book-10", testObj.Topic);
             Assert.AreEqual("XBT/USD", testObj.Symbol);
 
-            Assert.AreEqual("0.40100000", testObj.Data.Asks.ElementAt(1).QuantityLiteral);
-            Assert.AreEqual("5542.50000", testObj.Data.Asks.ElementAt(1).PriceLiteral);
+            Assert.AreEqual("0.40100000", testObj.Data.Asks.ElementAt(1).RawQuantity);
+            Assert.AreEqual("5542.50000", testObj.Data.Asks.ElementAt(1).RawPrice);
         }
     }
 }

--- a/Kraken.Net/Kraken.Net.xml
+++ b/Kraken.Net/Kraken.Net.xml
@@ -2166,11 +2166,17 @@
             Price of the entry
             </summary>
         </member>
+        <member name="P:Kraken.Net.Objects.KrakenStreamOrderBookEntry.PriceLiteral">
+            <summary>
+            Price of the entry as a string literal
+            </summary>
+        </member>
         <member name="P:Kraken.Net.Objects.KrakenStreamOrderBookEntry.Quantity">
             <summary>
             Quantity of the entry
             </summary>
         </member>
+        <!-- Badly formed XML comment ignored for member "P:Kraken.Net.Objects.KrakenStreamOrderBookEntry.QuantityLiteral" -->
         <member name="P:Kraken.Net.Objects.KrakenStreamOrderBookEntry.Timestamp">
             <summary>
             Timestamp of the entry

--- a/Kraken.Net/Kraken.Net.xml
+++ b/Kraken.Net/Kraken.Net.xml
@@ -2121,11 +2121,17 @@
             Price of the entry
             </summary>
         </member>
+        <member name="P:Kraken.Net.Objects.KrakenOrderBookEntry.RawPrice">
+            <summary>
+            Price of the entry as a string literal
+            </summary>
+        </member>
         <member name="P:Kraken.Net.Objects.KrakenOrderBookEntry.Quantity">
             <summary>
             Quantity of the entry
             </summary>
         </member>
+        <!-- Badly formed XML comment ignored for member "P:Kraken.Net.Objects.KrakenOrderBookEntry.RawQuantity" -->
         <member name="P:Kraken.Net.Objects.KrakenOrderBookEntry.Timestamp">
             <summary>
             Timestamp of change
@@ -2166,7 +2172,7 @@
             Price of the entry
             </summary>
         </member>
-        <member name="P:Kraken.Net.Objects.KrakenStreamOrderBookEntry.PriceLiteral">
+        <member name="P:Kraken.Net.Objects.KrakenStreamOrderBookEntry.RawPrice">
             <summary>
             Price of the entry as a string literal
             </summary>
@@ -2176,7 +2182,7 @@
             Quantity of the entry
             </summary>
         </member>
-        <!-- Badly formed XML comment ignored for member "P:Kraken.Net.Objects.KrakenStreamOrderBookEntry.QuantityLiteral" -->
+        <!-- Badly formed XML comment ignored for member "P:Kraken.Net.Objects.KrakenStreamOrderBookEntry.RawQuantity" -->
         <member name="P:Kraken.Net.Objects.KrakenStreamOrderBookEntry.Timestamp">
             <summary>
             Timestamp of the entry

--- a/Kraken.Net/KrakenSymbolOrderBook.cs
+++ b/Kraken.Net/KrakenSymbolOrderBook.cs
@@ -75,13 +75,15 @@ namespace Kraken.Net
             var checksumValues = new List<string>();
             for (var i = 0; i < 10; i++)
             {
-                checksumValues.Add(ToChecksumString(asks.ElementAt(i).Value.Price));
-                checksumValues.Add(ToChecksumString(asks.ElementAt(i).Value.Quantity));
+                var ask = (KrakenOrderBookEntry)asks.ElementAt(i).Value;
+                checksumValues.Add(ToChecksumString(ask.RawPrice));
+                checksumValues.Add(ToChecksumString(ask.RawQuantity));
             }
             for (var i = 0; i < 10; i++)
             {
-                checksumValues.Add(ToChecksumString(bids.ElementAt(i).Value.Price));
-                checksumValues.Add(ToChecksumString(bids.ElementAt(i).Value.Quantity));
+                var bid = (KrakenOrderBookEntry)bids.ElementAt(i).Value;
+                checksumValues.Add(ToChecksumString(bid.RawPrice));
+                checksumValues.Add(ToChecksumString(bid.RawQuantity));
             }
 
             var checksumString = string.Join("", checksumValues);
@@ -96,12 +98,9 @@ namespace Kraken.Net
             return true;
         }
 
-        private string ToChecksumString(decimal value)
+        private string ToChecksumString(string value)
         {
-            var str = value.ToString(CultureInfo.InvariantCulture);
-            str = str.Replace(".", "");
-            str = str.TrimStart('0');
-            return str;
+            return value.Replace(".", "").TrimStart('0');
         }
 
         /// <inheritdoc />

--- a/Kraken.Net/Objects/KrakenOrderBook.cs
+++ b/Kraken.Net/Objects/KrakenOrderBook.cs
@@ -33,10 +33,20 @@ namespace Kraken.Net.Objects
         [ArrayProperty(0)]
         public decimal Price { get; set; }
         /// <summary>
+        /// Price of the entry as a string literal
+        /// </summary>
+        [ArrayProperty(0)]
+        public string RawPrice { get; set; }
+        /// <summary>
         /// Quantity of the entry
         /// </summary>
         [ArrayProperty(1)]
         public decimal Quantity { get; set; }
+        // <summary>
+        /// Quantity of the entry as a string literal
+        /// </summary>
+        [ArrayProperty(1)]
+        public string RawQuantity { get; set; }
         /// <summary>
         /// Timestamp of change
         /// </summary>
@@ -91,7 +101,7 @@ namespace Kraken.Net.Objects
         /// Price of the entry as a string literal
         /// </summary>
         [ArrayProperty(0)]
-        public string PriceLiteral { get; set; }
+        public string RawPrice { get; set; }
 
         /// <summary>
         /// Quantity of the entry
@@ -103,7 +113,7 @@ namespace Kraken.Net.Objects
         /// Quantity of the entry as a string literal
         /// </summary>
         [ArrayProperty(1)]
-        public string QuantityLiteral { get; set; }
+        public string RawQuantity { get; set; }
 
         /// <summary>
         /// Timestamp of the entry

--- a/Kraken.Net/Objects/KrakenOrderBook.cs
+++ b/Kraken.Net/Objects/KrakenOrderBook.cs
@@ -25,7 +25,7 @@ namespace Kraken.Net.Objects
     /// Order book entry
     /// </summary>
     [JsonConverter(typeof(ArrayConverter))]
-    public class KrakenOrderBookEntry: ISymbolOrderBookEntry
+    public class KrakenOrderBookEntry : ISymbolOrderBookEntry
     {
         /// <summary>
         /// Price of the entry
@@ -86,11 +86,24 @@ namespace Kraken.Net.Objects
         /// </summary>
         [ArrayProperty(0)]
         public decimal Price { get; set; }
+
+        /// <summary>
+        /// Price of the entry as a string literal
+        /// </summary>
+        [ArrayProperty(0)]
+        public string PriceLiteral { get; set; }
+
         /// <summary>
         /// Quantity of the entry
         /// </summary>
         [ArrayProperty(1)]
         public decimal Quantity { get; set; }
+
+        // <summary>
+        /// Quantity of the entry as a string literal
+        /// </summary>
+        [ArrayProperty(1)]
+        public string QuantityLiteral { get; set; }
 
         /// <summary>
         /// Timestamp of the entry
@@ -103,7 +116,7 @@ namespace Kraken.Net.Objects
         /// </summary>
         [ArrayProperty(3)]
         public string UpdateType { get; set; } = "";
-        
+
         /// <summary>
         /// Sequence
         /// </summary>


### PR DESCRIPTION
In order to do the proper [checksum](https://docs.kraken.com/websockets/#book-checksum) when maintaining a Kraken orderbook locally, you need to have the original string literals of the web socket response of the orderbook updates. This is because when the values are casted to `decimal`s, they loose their trailing zeros, which are important to get the correct checksum value.

This PR adds the string literal of the price and the volume to the `KrakenStreamOrderbook`, so that it can be used by the client to do its own checksum calculation. It also adds a simple test for the `StreamOrderbookConverter`.