### PR TITLE
Change IEnumerable to Dictionary for KrakenTradeVolume Fees and Maker Fees

### DIFF
--- a/Kraken.Net/Objects/KrakenTradeVolume.cs
+++ b/Kraken.Net/Objects/KrakenTradeVolume.cs
@@ -51,11 +51,11 @@ namespace Kraken.Net.Objects
         /// <summary>
         /// Next fee
         /// </summary>
-        public decimal NextFee { get; set; }
+        public decimal? NextFee { get; set; }
         /// <summary>
         /// Next volume
         /// </summary>
-        public decimal NextVolume { get; set; }
+        public decimal? NextVolume { get; set; }
         /// <summary>
         /// Tier volume
         /// </summary>

--- a/Kraken.Net/Objects/KrakenTradeVolume.cs
+++ b/Kraken.Net/Objects/KrakenTradeVolume.cs
@@ -20,12 +20,13 @@ namespace Kraken.Net.Objects
         /// <summary>
         /// Fees structure
         /// </summary>
-        public IEnumerable<KrakenFeeStruct> Fees { get; set; } = new List<KrakenFeeStruct>();
+        public Dictionary<string, KrakenFeeStruct> Fees { get; set; } = new Dictionary<string, KrakenFeeStruct>();
+
         /// <summary>
         /// Maker fees structure
         /// </summary>
         [JsonProperty("fees_maker")]
-        public IEnumerable<KrakenFeeStruct> MakerFees { get; set; } = new List<KrakenFeeStruct>();
+        public Dictionary<string, KrakenFeeStruct> MakerFees { get; set; } = new Dictionary<string, KrakenFeeStruct>();
     }
 
     /// <summary>


### PR DESCRIPTION
Here is a fix for issue #37 I have opened earlier.
This fixes the JSON deserialization exception thrown when deserializing the properties Fees and MakerFess. A Dictionary<string, KrakenFeeStruct> is used to deserialize the pair and its fees structure.