### PR TITLE
Added staking support

### DIFF
--- a/Kraken.Net/Clients/SpotApi/KrakenClientSpotApi.cs
+++ b/Kraken.Net/Clients/SpotApi/KrakenClientSpotApi.cs
@@ -39,6 +39,9 @@ namespace Kraken.Net.Clients.SpotApi
         public IKrakenClientSpotApiTrading Trading { get; }
 
         /// <inheritdoc />
+        public IKrakenClientSpotStakingApi Staking { get; }
+
+        /// <inheritdoc />
         public string ExchangeName => "Kraken";
         #endregion
 
@@ -62,6 +65,7 @@ namespace Kraken.Net.Clients.SpotApi
             Account = new KrakenClientSpotApiAccount(this);
             ExchangeData = new KrakenClientSpotApiExchangeData(this);
             Trading = new KrakenClientSpotApiTrading(this);
+            Staking = new KrakenClientSpotStakingApi(this);
 
             requestBodyFormat = RequestBodyFormat.FormData;
         }

--- a/Kraken.Net/Clients/SpotApi/KrakenClientSpotStakingApi.cs
+++ b/Kraken.Net/Clients/SpotApi/KrakenClientSpotStakingApi.cs
@@ -1,0 +1,88 @@
+﻿namespace Kraken.Net.Clients.SpotApi
+{
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    using CryptoExchange.Net;
+    using CryptoExchange.Net.Objects;
+
+    using Kraken.Net.Interfaces.Clients.SpotApi;
+    using Kraken.Net.Objects.Models;
+
+    /// <inheritdoc />
+    public class KrakenClientSpotStakingApi : IKrakenClientSpotStakingApi
+    {
+        private readonly KrakenClientSpotApi _baseClient;
+
+        internal KrakenClientSpotStakingApi(KrakenClientSpotApi baseClient)
+        {
+            _baseClient = baseClient;
+        }
+
+        /// <inheritdoc />
+        public async Task<WebCallResult<KrakenStakeResponse>> StakeAsync(
+            string asset,
+            decimal amount,
+            string method,
+            string? twoFactorPassword = null,
+            CancellationToken ct = default)
+        {
+            var parameters = new Dictionary<string, object>();
+            parameters.AddOptionalParameter("asset", asset);
+            parameters.AddOptionalParameter("amount", amount.ToString(CultureInfo.InvariantCulture));
+            parameters.AddOptionalParameter("method", method);
+            parameters.AddOptionalParameter("otp", twoFactorPassword ?? _baseClient.ClientOptions.StaticTwoFactorAuthenticationPassword);
+
+            return await _baseClient.Execute<KrakenStakeResponse>(_baseClient.GetUri("0/private/Stake"), HttpMethod.Post, ct, parameters, true).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task<WebCallResult<KrakenUnstakeResponse>> UnstakeAsync(
+            string asset,
+            decimal amount,
+            string method,
+            string? twoFactorPassword = null,
+            CancellationToken ct = default)
+        {
+            var parameters = new Dictionary<string, object>();
+            parameters.AddOptionalParameter("asset", asset);
+            parameters.AddOptionalParameter("amount", amount.ToString(CultureInfo.InvariantCulture));
+            parameters.AddOptionalParameter("method", method);
+            parameters.AddOptionalParameter("otp", twoFactorPassword ?? _baseClient.ClientOptions.StaticTwoFactorAuthenticationPassword);
+
+            return await _baseClient.Execute<KrakenUnstakeResponse>(_baseClient.GetUri("0/private/Unstake"), HttpMethod.Post, ct, parameters, true).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task<WebCallResult<IEnumerable<KrakenStakingTransaction>>> GetPendingTransactionsAsync(
+            string? twoFactorPassword = null,
+            CancellationToken ct = default)
+        {
+            var parameters = new Dictionary<string, object>();
+            parameters.AddOptionalParameter("otp", twoFactorPassword ?? _baseClient.ClientOptions.StaticTwoFactorAuthenticationPassword);
+
+            return await _baseClient.Execute<IEnumerable<KrakenStakingTransaction>>(_baseClient.GetUri("0/private/Staking/Pending"), HttpMethod.Post, ct, parameters, true).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task<WebCallResult<IEnumerable<KrakenStakingTransaction>>> GetRecentTransactionsAsync(string? twoFactorPassword = null, CancellationToken ct = default)
+        {
+            var parameters = new Dictionary<string, object>();
+            parameters.AddOptionalParameter("otp", twoFactorPassword ?? _baseClient.ClientOptions.StaticTwoFactorAuthenticationPassword);
+
+            return await _baseClient.Execute<IEnumerable<KrakenStakingTransaction>>(_baseClient.GetUri("0/private/Staking/Transactions"), HttpMethod.Post, ct, parameters, true).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task<WebCallResult<IEnumerable<KrakenStakingAsset>>> GetStackableAssets(string? twoFactorPassword = null, CancellationToken ct = default)
+        {
+            var parameters = new Dictionary<string, object>();
+            parameters.AddOptionalParameter("otp", twoFactorPassword ?? _baseClient.ClientOptions.StaticTwoFactorAuthenticationPassword);
+
+            return await _baseClient.Execute<IEnumerable<KrakenStakingAsset>>(_baseClient.GetUri("0/private/Staking/Assets"), HttpMethod.Post, ct, parameters, true).ConfigureAwait(false);
+        }
+    }
+}

--- a/Kraken.Net/Converters/LedgerEntryTypeConverter.cs
+++ b/Kraken.Net/Converters/LedgerEntryTypeConverter.cs
@@ -21,6 +21,7 @@ namespace Kraken.Net.Converters
             new KeyValuePair<LedgerEntryType, string>(LedgerEntryType.Spend, "spend"),
             new KeyValuePair<LedgerEntryType, string>(LedgerEntryType.Receive, "receive"),
             new KeyValuePair<LedgerEntryType, string>(LedgerEntryType.Settled, "settled"),
+            new KeyValuePair<LedgerEntryType, string>(LedgerEntryType.Staking, "staking"),
         };
     }
 }

--- a/Kraken.Net/Converters/StakingRewardTypeConverter.cs
+++ b/Kraken.Net/Converters/StakingRewardTypeConverter.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using CryptoExchange.Net.Converters;
+using Kraken.Net.Enums;
+
+namespace Kraken.Net.Converters
+{
+    internal class StakingRewardTypeConverter : BaseConverter<StakingRewardType>
+    {
+        public StakingRewardTypeConverter() : this(true) { }
+        public StakingRewardTypeConverter(bool quotes) : base(quotes) { }
+
+        protected override List<KeyValuePair<StakingRewardType, string>> Mapping => new List<KeyValuePair<StakingRewardType, string>>
+        {
+            new KeyValuePair<StakingRewardType, string>(StakingRewardType.Percentage, "percentage")
+        };
+    }
+}

--- a/Kraken.Net/Converters/StakingTransactionStatusConverter.cs
+++ b/Kraken.Net/Converters/StakingTransactionStatusConverter.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using CryptoExchange.Net.Converters;
+using Kraken.Net.Enums;
+
+namespace Kraken.Net.Converters
+{
+    internal class StakingTransactionStatusConverter : BaseConverter<StakingTransactionStatus>
+    {
+        public StakingTransactionStatusConverter() : this(true) { }
+        public StakingTransactionStatusConverter(bool quotes) : base(quotes) { }
+
+        protected override List<KeyValuePair<StakingTransactionStatus, string>> Mapping => new List<KeyValuePair<StakingTransactionStatus, string>>
+        {
+            new KeyValuePair<StakingTransactionStatus, string>(StakingTransactionStatus.Failure, "failure"),
+            new KeyValuePair<StakingTransactionStatus, string>(StakingTransactionStatus.Initial, "initial"),
+            new KeyValuePair<StakingTransactionStatus, string>(StakingTransactionStatus.Pending, "pending"),
+            new KeyValuePair<StakingTransactionStatus, string>(StakingTransactionStatus.Settled, "settled"),
+            new KeyValuePair<StakingTransactionStatus, string>(StakingTransactionStatus.Success, "success"),
+        };
+    }
+}

--- a/Kraken.Net/Converters/StakingTypeConverter.cs
+++ b/Kraken.Net/Converters/StakingTypeConverter.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using CryptoExchange.Net.Converters;
+using Kraken.Net.Enums;
+
+namespace Kraken.Net.Converters
+{
+    internal class StakingTypeConverter : BaseConverter<StakingType>
+    {
+        public StakingTypeConverter() : this(true) { }
+        public StakingTypeConverter(bool quotes) : base(quotes) { }
+
+        protected override List<KeyValuePair<StakingType, string>> Mapping => new List<KeyValuePair<StakingType, string>>
+        {
+            new KeyValuePair<StakingType, string>(StakingType.Bonding, "bonding"),
+            new KeyValuePair<StakingType, string>(StakingType.Reward, "reward"),
+            new KeyValuePair<StakingType, string>(StakingType.Unbonding, "unbonding"),
+        };
+    }
+}

--- a/Kraken.Net/Enums/LedgerEntryType.cs
+++ b/Kraken.Net/Enums/LedgerEntryType.cs
@@ -44,6 +44,10 @@
         /// <summary>
         /// Settled
         /// </summary>
-        Settled
+        Settled,
+        /// <summary>
+        /// Staking
+        /// </summary>
+        Staking
     }
 }

--- a/Kraken.Net/Enums/StakingRewardType.cs
+++ b/Kraken.Net/Enums/StakingRewardType.cs
@@ -1,0 +1,13 @@
+﻿namespace Kraken.Net.Enums
+{
+    /// <summary>
+    /// Reward type
+    /// </summary>
+    public enum StakingRewardType
+    {
+        /// <summary>
+        /// Percentage
+        /// </summary>
+        Percentage
+    }
+}

--- a/Kraken.Net/Enums/StakingTransactionStatus.cs
+++ b/Kraken.Net/Enums/StakingTransactionStatus.cs
@@ -1,0 +1,15 @@
+﻿namespace Kraken.Net.Enums
+{
+    /// <summary>
+    /// The current status of the staking transaction.
+    /// </summary>
+    public enum StakingTransactionStatus
+    {
+#pragma warning disable CS1591
+        Initial,
+        Pending,
+        Settled,
+        Success,
+        Failure
+    }
+}

--- a/Kraken.Net/Enums/StakingType.cs
+++ b/Kraken.Net/Enums/StakingType.cs
@@ -1,0 +1,13 @@
+﻿namespace Kraken.Net.Enums
+{
+    /// <summary>
+    /// The type of transaction.
+    /// </summary>
+    public enum StakingType
+    {
+#pragma warning disable CS1591
+        Bonding,
+        Reward,
+        Unbonding
+    }
+}

--- a/Kraken.Net/Interfaces/Clients/SpotApi/IKrakenClientSpotApi.cs
+++ b/Kraken.Net/Interfaces/Clients/SpotApi/IKrakenClientSpotApi.cs
@@ -25,6 +25,11 @@ namespace Kraken.Net.Interfaces.Clients.SpotApi
         IKrakenClientSpotApiTrading Trading { get; }
 
         /// <summary>
+        /// Endpoints related to staking assets
+        /// </summary>
+        IKrakenClientSpotStakingApi Staking { get; }
+
+        /// <summary>
         /// Get the ISpotClient for this client. This is a common interface which allows for some basic operations without knowing any details of the exchange.
         /// </summary>
         /// <returns></returns>

--- a/Kraken.Net/Interfaces/Clients/SpotApi/IKrakenClientSpotStakingApi.cs
+++ b/Kraken.Net/Interfaces/Clients/SpotApi/IKrakenClientSpotStakingApi.cs
@@ -1,0 +1,69 @@
+﻿namespace Kraken.Net.Interfaces.Clients.SpotApi
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    using CryptoExchange.Net.Objects;
+
+    using Kraken.Net.Objects.Models;
+
+    /// <summary>
+    /// Kraken stacking endpoints.
+    /// </summary>
+    public interface IKrakenClientSpotStakingApi
+    {
+        /// <summary>
+        /// Stake an asset from your spot wallet.
+        /// <para><a href="https://docs.kraken.com/rest/#operation/stake"/></para>
+        /// </summary>
+        /// <param name="asset">Asset to stake (asset ID or altname) e.g. DOT</param>
+        /// <param name="amount">Amount of the asset to stake</param>
+        /// <param name="method">Name of the staking option to use as returned by <see cref="KrakenStakingAsset.Method"/></param>
+        /// <param name="twoFactorPassword">Password or authentication app code if enabled</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <seealso cref="GetStackableAssets"/>
+        /// <returns>A reference to the staking request.</returns>
+        Task<WebCallResult<KrakenStakeResponse>> StakeAsync(string asset, decimal amount, string method, string? twoFactorPassword = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Unstake an asset from your staking wallet
+        /// <para><a href="https://docs.kraken.com/rest/#operation/unstake"/></para>
+        /// </summary>
+        /// <param name="asset">Asset to unstake (asset ID or altname). Must be a valid staking asset (e.g. XBT.M, XTZ.S, ADA.S)</param>
+        /// <param name="amount">Amount of the asset to stake</param>
+        /// <param name="method">Amount of the asset to stake</param>
+        /// <param name="twoFactorPassword">Password or authentication app code if enabled</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>A reference to the unstaking request.</returns>
+        Task<WebCallResult<KrakenUnstakeResponse>> UnstakeAsync(string asset, decimal amount, string method, string? twoFactorPassword = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Returns the list of pending staking transactions. Once completed, these transactions will be accessible
+        /// through <see cref="GetRecentTransactionsAsync"/> and will not be accessible through this API.
+        /// <para><a href="https://docs.kraken.com/rest/#operation/getStakingPendingDeposits"/></para>
+        /// </summary>
+        /// <param name="twoFactorPassword"></param>
+        /// <param name="ct"></param>
+        /// <returns></returns>
+        Task<WebCallResult<IEnumerable<KrakenStakingTransaction>>> GetPendingTransactionsAsync(string? twoFactorPassword = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Returns a list of 1000 recent staking transactions from past 90 days.
+        /// <para><a href="https://docs.kraken.com/rest/#operation/getStakingTransactions"/></para>
+        /// </summary>
+        /// <param name="twoFactorPassword">Password or authentication app code if enabled</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The last 1000 staking transactions from the past 90 days</returns>
+        Task<WebCallResult<IEnumerable<KrakenStakingTransaction>>> GetRecentTransactionsAsync(string? twoFactorPassword = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Returns the list of assets that you're able to stake.
+        /// <para><a href="https://docs.kraken.com/rest/#operation/getStakingAssetInfo"/></para>
+        /// </summary>
+        /// <param name="twoFactorPassword"></param>
+        /// <param name="ct"></param>
+        /// <returns></returns>
+        Task<WebCallResult<IEnumerable<KrakenStakingAsset>>> GetStackableAssets(string? twoFactorPassword = null, CancellationToken ct = default);
+    }
+}

--- a/Kraken.Net/Kraken.Net.xml
+++ b/Kraken.Net/Kraken.Net.xml
@@ -80,6 +80,9 @@
         <member name="P:Kraken.Net.Clients.SpotApi.KrakenClientSpotApi.Trading">
             <inheritdoc />
         </member>
+        <member name="P:Kraken.Net.Clients.SpotApi.KrakenClientSpotApi.Staking">
+            <inheritdoc />
+        </member>
         <member name="P:Kraken.Net.Clients.SpotApi.KrakenClientSpotApi.ExchangeName">
             <inheritdoc />
         </member>
@@ -219,6 +222,24 @@
             <inheritdoc />
         </member>
         <member name="M:Kraken.Net.Clients.SpotApi.KrakenClientSpotApiTrading.CancelOrderAsync(System.String,System.String,System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
+        <member name="T:Kraken.Net.Clients.SpotApi.KrakenClientSpotStakingApi">
+            <inheritdoc />
+        </member>
+        <member name="M:Kraken.Net.Clients.SpotApi.KrakenClientSpotStakingApi.StakeAsync(System.String,System.Decimal,System.String,System.String,System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
+        <member name="M:Kraken.Net.Clients.SpotApi.KrakenClientSpotStakingApi.UnstakeAsync(System.String,System.Decimal,System.String,System.String,System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
+        <member name="M:Kraken.Net.Clients.SpotApi.KrakenClientSpotStakingApi.GetPendingTransactionsAsync(System.String,System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
+        <member name="M:Kraken.Net.Clients.SpotApi.KrakenClientSpotStakingApi.GetRecentTransactionsAsync(System.String,System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
+        <member name="M:Kraken.Net.Clients.SpotApi.KrakenClientSpotStakingApi.GetStackableAssets(System.String,System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
         <member name="T:Kraken.Net.Clients.SpotApi.KrakenSocketClientSpotStreams">
@@ -415,6 +436,11 @@
             Settled
             </summary>
         </member>
+        <member name="F:Kraken.Net.Enums.LedgerEntryType.Staking">
+            <summary>
+            Staking
+            </summary>
+        </member>
         <member name="T:Kraken.Net.Enums.OrderFlags">
             <summary>
             Flags for an order
@@ -575,6 +601,26 @@
             Symbol order
             </summary>
         </member>
+        <member name="T:Kraken.Net.Enums.StakingRewardType">
+            <summary>
+            Reward type
+            </summary>
+        </member>
+        <member name="F:Kraken.Net.Enums.StakingRewardType.Percentage">
+            <summary>
+            Percentage
+            </summary>
+        </member>
+        <member name="T:Kraken.Net.Enums.StakingTransactionStatus">
+            <summary>
+            The current status of the staking transaction.
+            </summary>
+        </member>
+        <member name="T:Kraken.Net.Enums.StakingType">
+            <summary>
+            The type of transaction.
+            </summary>
+        </member>
         <member name="T:Kraken.Net.Enums.SystemStatus">
             <summary>
             System status info
@@ -638,6 +684,11 @@
         <member name="P:Kraken.Net.Interfaces.Clients.SpotApi.IKrakenClientSpotApi.Trading">
             <summary>
             Endpoints related to orders and trades
+            </summary>
+        </member>
+        <member name="P:Kraken.Net.Interfaces.Clients.SpotApi.IKrakenClientSpotApi.Staking">
+            <summary>
+            Endpoints related to staking assets
             </summary>
         </member>
         <member name="P:Kraken.Net.Interfaces.Clients.SpotApi.IKrakenClientSpotApi.CommonSpotClient">
@@ -1012,6 +1063,64 @@
             <param name="twoFactorPassword">Password or authentication app code if enabled</param>
             <param name="ct">Cancellation token</param>
             <returns>Cancel result</returns>
+        </member>
+        <member name="T:Kraken.Net.Interfaces.Clients.SpotApi.IKrakenClientSpotStakingApi">
+            <summary>
+            Kraken stacking endpoints.
+            </summary>
+        </member>
+        <member name="M:Kraken.Net.Interfaces.Clients.SpotApi.IKrakenClientSpotStakingApi.StakeAsync(System.String,System.Decimal,System.String,System.String,System.Threading.CancellationToken)">
+            <summary>
+            Stake an asset from your spot wallet.
+            <para><a href="https://docs.kraken.com/rest/#operation/stake"/></para>
+            </summary>
+            <param name="asset">Asset to stake (asset ID or altname) e.g. DOT</param>
+            <param name="amount">Amount of the asset to stake</param>
+            <param name="method">Name of the staking option to use as returned by <see cref="P:Kraken.Net.Objects.Models.KrakenStakingAsset.Method"/></param>
+            <param name="twoFactorPassword">Password or authentication app code if enabled</param>
+            <param name="ct">Cancellation token</param>
+            <seealso cref="M:Kraken.Net.Interfaces.Clients.SpotApi.IKrakenClientSpotStakingApi.GetStackableAssets(System.String,System.Threading.CancellationToken)"/>
+            <returns>A reference to the staking request.</returns>
+        </member>
+        <member name="M:Kraken.Net.Interfaces.Clients.SpotApi.IKrakenClientSpotStakingApi.UnstakeAsync(System.String,System.Decimal,System.String,System.String,System.Threading.CancellationToken)">
+            <summary>
+            Unstake an asset from your staking wallet
+            <para><a href="https://docs.kraken.com/rest/#operation/unstake"/></para>
+            </summary>
+            <param name="asset">Asset to unstake (asset ID or altname). Must be a valid staking asset (e.g. XBT.M, XTZ.S, ADA.S)</param>
+            <param name="amount">Amount of the asset to stake</param>
+            <param name="method">Amount of the asset to stake</param>
+            <param name="twoFactorPassword">Password or authentication app code if enabled</param>
+            <param name="ct">Cancellation token</param>
+            <returns>A reference to the unstaking request.</returns>
+        </member>
+        <member name="M:Kraken.Net.Interfaces.Clients.SpotApi.IKrakenClientSpotStakingApi.GetPendingTransactionsAsync(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Returns the list of pending staking transactions. Once completed, these transactions will be accessible
+            through <see cref="M:Kraken.Net.Interfaces.Clients.SpotApi.IKrakenClientSpotStakingApi.GetRecentTransactionsAsync(System.String,System.Threading.CancellationToken)"/> and will not be accessible through this API.
+            <para><a href="https://docs.kraken.com/rest/#operation/getStakingPendingDeposits"/></para>
+            </summary>
+            <param name="twoFactorPassword"></param>
+            <param name="ct"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Kraken.Net.Interfaces.Clients.SpotApi.IKrakenClientSpotStakingApi.GetRecentTransactionsAsync(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Returns a list of 1000 recent staking transactions from past 90 days.
+            <para><a href="https://docs.kraken.com/rest/#operation/getStakingTransactions"/></para>
+            </summary>
+            <param name="twoFactorPassword">Password or authentication app code if enabled</param>
+            <param name="ct">Cancellation token</param>
+            <returns>The last 1000 staking transactions from the past 90 days</returns>
+        </member>
+        <member name="M:Kraken.Net.Interfaces.Clients.SpotApi.IKrakenClientSpotStakingApi.GetStackableAssets(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Returns the list of assets that you're able to stake.
+            <para><a href="https://docs.kraken.com/rest/#operation/getStakingAssetInfo"/></para>
+            </summary>
+            <param name="twoFactorPassword"></param>
+            <param name="ct"></param>
+            <returns></returns>
         </member>
         <member name="T:Kraken.Net.Interfaces.Clients.SpotApi.IKrakenSocketClientSpotStreams">
             <summary>
@@ -2269,6 +2378,147 @@
             Best ask quantity
             </summary>
         </member>
+        <member name="T:Kraken.Net.Objects.Models.KrakenStakeResponse">
+            <summary>
+            Kraken's response to a staking request.
+            </summary>
+        </member>
+        <member name="P:Kraken.Net.Objects.Models.KrakenStakeResponse.ReferenceId">
+            <summary>
+            Reference id which can be tracked back to a ledger entry corresponding to the
+            stacked asset (e.g. DOT.S).
+            </summary>
+        </member>
+        <member name="T:Kraken.Net.Objects.Models.KrakenStakingAsset">
+            <summary>
+            Represents an asset that can be staked by the user.
+            </summary>
+        </member>
+        <member name="P:Kraken.Net.Objects.Models.KrakenStakingAsset.Method">
+            <summary>
+            Unique ID of the staking option (used in Stake/Unstake operations).
+            </summary>
+        </member>
+        <member name="P:Kraken.Net.Objects.Models.KrakenStakingAsset.Asset">
+            <summary>
+            Asset code/name e.g. DOT.
+            </summary>
+        </member>
+        <member name="P:Kraken.Net.Objects.Models.KrakenStakingAsset.StakingAsset">
+            <summary>
+            Staking asset code/name e.g. DOT.S
+            </summary>
+        </member>
+        <member name="P:Kraken.Net.Objects.Models.KrakenStakingAsset.Rewards">
+            <summary>
+            Describes the rewards earned while staking.
+            </summary>
+        </member>
+        <member name="P:Kraken.Net.Objects.Models.KrakenStakingAsset.OnChain">
+            <summary>
+            Whether the staking operation is on-chain or not.
+            </summary>
+        </member>
+        <member name="P:Kraken.Net.Objects.Models.KrakenStakingAsset.CanStake">
+            <summary>
+            Whether the user will be able to stake this asset.
+            </summary>
+        </member>
+        <member name="P:Kraken.Net.Objects.Models.KrakenStakingAsset.CanUnstake">
+            <summary>
+            Whether the user will be able to unstake this asset.
+            </summary>
+        </member>
+        <member name="P:Kraken.Net.Objects.Models.KrakenStakingAsset.Minimums">
+            <summary>
+            Minimium amounts for staking/unstaking.
+            </summary>
+        </member>
+        <member name="T:Kraken.Net.Objects.Models.KrakenStakingMinimumInfo">
+            <summary>
+            Minimum amounts for staking/unstaking.
+            </summary>
+        </member>
+        <member name="P:Kraken.Net.Objects.Models.KrakenStakingMinimumInfo.Staking">
+            <summary>
+            The minimum amount of value that can be staked.
+            </summary>
+        </member>
+        <member name="P:Kraken.Net.Objects.Models.KrakenStakingMinimumInfo.Unstaking">
+            <summary>
+            The minimum amount of value that can be unstaked.
+            </summary>
+        </member>
+        <member name="T:Kraken.Net.Objects.Models.KrakenStakingRewardInfo">
+            <summary>
+            Describes the rewards earned while staking.
+            </summary>
+        </member>
+        <member name="P:Kraken.Net.Objects.Models.KrakenStakingRewardInfo.Reward">
+            <summary>
+            Reward earned while staking.
+            </summary>
+        </member>
+        <member name="P:Kraken.Net.Objects.Models.KrakenStakingRewardInfo.Type">
+            <summary>
+            The type of the reward e.g. "percentage".
+            </summary>
+        </member>
+        <member name="T:Kraken.Net.Objects.Models.KrakenStakingTransaction">
+            <summary>
+            Staking Transaction Info
+            </summary>
+        </member>
+        <member name="P:Kraken.Net.Objects.Models.KrakenStakingTransaction.Method">
+            <summary>
+            Stacking method as described by <see cref="P:Kraken.Net.Objects.Models.KrakenStakingAsset.Method"/>.
+            </summary>
+        </member>
+        <member name="P:Kraken.Net.Objects.Models.KrakenStakingTransaction.Asset">
+            <summary>
+            Asset code/name e.g. DOT
+            </summary>
+        </member>
+        <member name="P:Kraken.Net.Objects.Models.KrakenStakingTransaction.ReferenceId">
+            <summary>
+            The reference ID of the transaction.
+            </summary>
+        </member>
+        <member name="P:Kraken.Net.Objects.Models.KrakenStakingTransaction.Quantity">
+            <summary>
+            The transaction amount.
+            </summary>
+        </member>
+        <member name="P:Kraken.Net.Objects.Models.KrakenStakingTransaction.Fee">
+            <summary>
+            Transaction fee.
+            </summary>
+        </member>
+        <member name="P:Kraken.Net.Objects.Models.KrakenStakingTransaction.Timestamp">
+            <summary>
+            Unix timestamp when the transaction was initiated.
+            </summary>
+        </member>
+        <member name="P:Kraken.Net.Objects.Models.KrakenStakingTransaction.Status">
+            <summary>
+            Transaction status.
+            </summary>
+        </member>
+        <member name="P:Kraken.Net.Objects.Models.KrakenStakingTransaction.Type">
+            <summary>
+            Transaction type.
+            </summary>
+        </member>
+        <member name="P:Kraken.Net.Objects.Models.KrakenStakingTransaction.BondStart">
+            <summary>
+            Unix timestamp from the start of bond period (applicable only to bonding transactions).
+            </summary>
+        </member>
+        <member name="P:Kraken.Net.Objects.Models.KrakenStakingTransaction.BondEnd">
+            <summary>
+            Unix timestamp from the start of bond period (applicable only to bonding transactions).
+            </summary>
+        </member>
         <member name="T:Kraken.Net.Objects.Models.KrakenSymbol">
             <summary>
             Symbol info
@@ -2643,6 +2893,17 @@
         <member name="P:Kraken.Net.Objects.Models.KrakenFeeStruct.TierVolume">
             <summary>
             Tier volume
+            </summary>
+        </member>
+        <member name="T:Kraken.Net.Objects.Models.KrakenUnstakeResponse">
+            <summary>
+            Kraken's response to an unstaking request.
+            </summary>
+        </member>
+        <member name="P:Kraken.Net.Objects.Models.KrakenUnstakeResponse.ReferenceId">
+            <summary>
+            Reference id which can be tracked back to a ledger entry corresponding to the
+            unstacked asset (e.g. DOT.S).
             </summary>
         </member>
         <member name="T:Kraken.Net.Objects.Models.KrakenUserTrade">

--- a/Kraken.Net/Objects/Models/KrakenStakeResponse.cs
+++ b/Kraken.Net/Objects/Models/KrakenStakeResponse.cs
@@ -1,0 +1,17 @@
+﻿namespace Kraken.Net.Objects.Models
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Kraken's response to a staking request.
+    /// </summary>
+    public class KrakenStakeResponse
+    {
+        /// <summary>
+        /// Reference id which can be tracked back to a ledger entry corresponding to the
+        /// stacked asset (e.g. DOT.S).
+        /// </summary>
+        [JsonProperty("refid")]
+        public string ReferenceId { get; set; } = null!;
+    }
+}

--- a/Kraken.Net/Objects/Models/KrakenStakingAsset.cs
+++ b/Kraken.Net/Objects/Models/KrakenStakingAsset.cs
@@ -1,0 +1,58 @@
+﻿namespace Kraken.Net.Objects.Models
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Represents an asset that can be staked by the user.
+    /// </summary>
+    public class KrakenStakingAsset
+    {
+        /// <summary>
+        /// Unique ID of the staking option (used in Stake/Unstake operations).
+        /// </summary>
+        [JsonProperty("method")]
+        public string Method { get; set; } = null!;
+
+        /// <summary>
+        /// Asset code/name e.g. DOT.
+        /// </summary>
+        [JsonProperty("asset")]
+        public string Asset { get; set; } = null!;
+
+        /// <summary>
+        /// Staking asset code/name e.g. DOT.S
+        /// </summary>
+        [JsonProperty("staking_asset")]
+        public string StakingAsset { get; set; } = null!;
+
+        /// <summary>
+        /// Describes the rewards earned while staking.
+        /// </summary>
+        [JsonProperty("rewards")]
+        public KrakenStakingRewardInfo? Rewards { get; set; }
+
+        /// <summary>
+        /// Whether the staking operation is on-chain or not.
+        /// </summary>
+        [JsonProperty("on_chain")]
+        public bool OnChain { get; set; }
+
+        /// <summary>
+        /// Whether the user will be able to stake this asset.
+        /// </summary>
+        [JsonProperty("can_stake")]
+        public bool CanStake { get; set; }
+
+        /// <summary>
+        /// Whether the user will be able to unstake this asset.
+        /// </summary>
+        [JsonProperty("can_unstake")]
+        public bool CanUnstake { get; set; }
+
+        /// <summary>
+        /// Minimium amounts for staking/unstaking.
+        /// </summary>
+        [JsonProperty("minimum_amount")]
+        public KrakenStakingMinimumInfo? Minimums { get; set; }
+    }
+}

--- a/Kraken.Net/Objects/Models/KrakenStakingMinimumInfo.cs
+++ b/Kraken.Net/Objects/Models/KrakenStakingMinimumInfo.cs
@@ -1,0 +1,22 @@
+﻿namespace Kraken.Net.Objects.Models
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Minimum amounts for staking/unstaking.
+    /// </summary>
+    public class KrakenStakingMinimumInfo
+    {
+        /// <summary>
+        /// The minimum amount of value that can be staked.
+        /// </summary>
+        [JsonProperty("staking")]
+        public decimal Staking { get; set; }
+
+        /// <summary>
+        /// The minimum amount of value that can be unstaked.
+        /// </summary>
+        [JsonProperty("unstaking")]
+        public decimal Unstaking { get; set; }
+    }
+}

--- a/Kraken.Net/Objects/Models/KrakenStakingRewardInfo.cs
+++ b/Kraken.Net/Objects/Models/KrakenStakingRewardInfo.cs
@@ -1,0 +1,26 @@
+﻿namespace Kraken.Net.Objects.Models
+{
+    using Kraken.Net.Converters;
+    using Kraken.Net.Enums;
+
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Describes the rewards earned while staking.
+    /// </summary>
+    public class KrakenStakingRewardInfo
+    {
+        /// <summary>
+        /// Reward earned while staking.
+        /// </summary>
+        [JsonProperty("reward")]
+        public string? Reward { get; set; }
+
+        /// <summary>
+        /// The type of the reward e.g. "percentage".
+        /// </summary>
+
+        [JsonProperty("type"), JsonConverter(typeof(StakingRewardTypeConverter))]
+        public StakingRewardType Type { get; set; }
+    }
+}

--- a/Kraken.Net/Objects/Models/KrakenStakingTransaction.cs
+++ b/Kraken.Net/Objects/Models/KrakenStakingTransaction.cs
@@ -1,0 +1,76 @@
+﻿namespace Kraken.Net.Objects.Models
+{
+    using System;
+
+    using CryptoExchange.Net.Converters;
+
+    using Kraken.Net.Converters;
+    using Kraken.Net.Enums;
+
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Staking Transaction Info
+    /// </summary>
+    public class KrakenStakingTransaction
+    {
+        /// <summary>
+        /// Stacking method as described by <see cref="KrakenStakingAsset.Method"/>.
+        /// </summary>
+        public string Method { get; set; } = null!;
+
+        /// <summary>
+        /// Asset code/name e.g. DOT
+        /// </summary>
+        [JsonProperty("asset")]
+        public string Asset { get; set; } = null!;
+
+        /// <summary>
+        /// The reference ID of the transaction.
+        /// </summary>
+        [JsonProperty("refid")]
+        public string ReferenceId { get; set; } = null!;
+
+        /// <summary>
+        /// The transaction amount.
+        /// </summary>
+        [JsonProperty("amount")]
+        public decimal Quantity { get; set; }
+
+        /// <summary>
+        /// Transaction fee.
+        /// </summary>
+        [JsonProperty("fee")]
+        public decimal? Fee { get; set; }
+
+        /// <summary>
+        /// Unix timestamp when the transaction was initiated.
+        /// </summary>
+        [JsonProperty("time"), JsonConverter(typeof(DateTimeConverter))]
+        public DateTime Timestamp { get; set; }
+
+        /// <summary>
+        /// Transaction status.
+        /// </summary>
+        [JsonProperty("status"), JsonConverter(typeof(StakingTransactionStatusConverter))]
+        public StakingTransactionStatus Status { get; set; }
+
+        /// <summary>
+        /// Transaction type.
+        /// </summary>
+        [JsonProperty("type"), JsonConverter(typeof(StakingTypeConverter))]
+        public StakingType Type { get; set; }
+
+        /// <summary>
+        /// Unix timestamp from the start of bond period (applicable only to bonding transactions).
+        /// </summary>
+        [JsonProperty("bond_start"), JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? BondStart { get; set; }
+
+        /// <summary>
+        /// Unix timestamp from the start of bond period (applicable only to bonding transactions).
+        /// </summary>
+        [JsonProperty("bond_end"), JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? BondEnd { get; set; }
+    }
+}

--- a/Kraken.Net/Objects/Models/KrakenUnstakeResponse.cs
+++ b/Kraken.Net/Objects/Models/KrakenUnstakeResponse.cs
@@ -1,0 +1,17 @@
+﻿namespace Kraken.Net.Objects.Models
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Kraken's response to an unstaking request.
+    /// </summary>
+    public class KrakenUnstakeResponse
+    {
+        /// <summary>
+        /// Reference id which can be tracked back to a ledger entry corresponding to the
+        /// unstacked asset (e.g. DOT.S).
+        /// </summary>
+        [JsonProperty("refid")]
+        public string ReferenceId { get; set; } = null!;
+    }
+}


### PR DESCRIPTION
Kraken's public REST API supports 5 staking endpoints:
- get stakable assets
- stake
- unstake
- get recent transactions
- get pending transactions
The first one should be used to retrieve the necessary
parameters that need to be passed when staking or
unstaking.
The last 2 APIs let you monitor the (un)staking requests,
though the kraken API is a bit unintuitive - the refid of
those requests are not present in the transactions API.
The refid is a ledger id.

This commit also adds a new LedgerEntryType - Staking.