### PR TITLE
IKrakenClientSpotStakingApi::StakeAsync no longer produces a doc warning

### DIFF
--- a/Kraken.Net/Interfaces/Clients/SpotApi/IKrakenClientSpotStakingApi.cs
+++ b/Kraken.Net/Interfaces/Clients/SpotApi/IKrakenClientSpotStakingApi.cs
@@ -22,7 +22,7 @@
         /// <param name="method">Name of the staking option to use as returned by <see cref="KrakenStakingAsset.Method"/></param>
         /// <param name="twoFactorPassword">Password or authentication app code if enabled</param>
         /// <param name="ct">Cancellation token</param>
-        /// <seealso cref="GetStackableAssets"/>
+        /// <seealso cref="GetStakableAssets"/>
         /// <returns>A reference to the staking request.</returns>
         Task<WebCallResult<KrakenStakeResponse>> StakeAsync(string asset, decimal amount, string method, string? twoFactorPassword = null, CancellationToken ct = default);
 

--- a/Kraken.Net/Kraken.Net.xml
+++ b/Kraken.Net/Kraken.Net.xml
@@ -1079,7 +1079,7 @@
             <param name="method">Name of the staking option to use as returned by <see cref="P:Kraken.Net.Objects.Models.KrakenStakingAsset.Method"/></param>
             <param name="twoFactorPassword">Password or authentication app code if enabled</param>
             <param name="ct">Cancellation token</param>
-            <seealso cref="!:GetStackableAssets"/>
+            <seealso cref="M:Kraken.Net.Interfaces.Clients.SpotApi.IKrakenClientSpotStakingApi.GetStakableAssets(System.String,System.Threading.CancellationToken)"/>
             <returns>A reference to the staking request.</returns>
         </member>
         <member name="M:Kraken.Net.Interfaces.Clients.SpotApi.IKrakenClientSpotStakingApi.UnstakeAsync(System.String,System.Decimal,System.String,System.String,System.Threading.CancellationToken)">


### PR DESCRIPTION
The documentation now correctly references the GetStakableAssets
and there's no warning about a missing method "GetStackableAssets".