### PR TITLE
Update the docs to specify that the manual creation of a KrakenRestClient might cause socket exhaustion

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -19,6 +19,8 @@ var krakenSocketClient = new KrakenSocketClient(options =>
 });
 ```
 
+**Warning:** This creates a new HttpClient for each instance and could lead to sockets exhaustion under high load. Favor the usage of the HttpClientFactory achieved via registration in the DI container described below or use the overloaded constructor to inject your own HttpClient.
+
 *Using dotnet dependency inject*
 ```csharp
 services.AddKraken(


### PR DESCRIPTION
As discussed on Discord https://discord.com/channels/847020490588422145/847023196527788042/1131593460789542952 the manual creation of a krakenRestClient is creating a new HttpClient each time which might cause socket exhaustion as described in https://learn.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests
The sugested solutions in the docs are either using the extension method on the service collection to use the IHttpClientFactory or inject a HttpClient in the overloaded constructor.