### PR TITLE
LongPositionLimit and ShortPositionLimit datatype fix

### DIFF
--- a/Kraken.Net/Objects/Models/KrakenSymbol.cs
+++ b/Kraken.Net/Objects/Models/KrakenSymbol.cs
@@ -118,11 +118,11 @@ namespace Kraken.Net.Objects.Models
         /// Long position limit
         /// </summary>
         [JsonProperty("long_position_limit")]
-        public int LongPositionLimit { get; set; }
+        public long LongPositionLimit { get; set; }
         /// <summary>
         /// Short position limit
         /// </summary>
         [JsonProperty("short_position_limit")]
-        public int ShortPositionLimit { get; set; }
+        public long ShortPositionLimit { get; set; }
     }
 }


### PR DESCRIPTION
An error occurs when method client.SpotApi.ExchangeData.GetSymbolsAsync() is called..

Deserialize JsonReaderException: Could not convert to integer: 6000000000. Path 'result.PEPEUSD.long_position_limit', line 1, position 290765., Path: result.PEPEUSD.long_position_limit, LineNumber: 1, LinePosition: 290765