### PR TITLE
Futures user trades - include milliseconds into lastFillTime parameter

### DIFF
--- a/Kraken.Net/Clients/FuturesApi/KrakenRestClientFuturesApiTrading.cs
+++ b/Kraken.Net/Clients/FuturesApi/KrakenRestClientFuturesApiTrading.cs
@@ -28,7 +28,7 @@ namespace Kraken.Net.Clients.FuturesApi
         public async Task<WebCallResult<IEnumerable<KrakenFuturesUserTrade>>> GetUserTradesAsync(DateTime? startTime = null, CancellationToken ct = default)
         {
             var parameters = new Dictionary<string, object>();
-            parameters.AddOptionalParameter("lastFillTime", startTime?.ToString("u").Replace(" ", "T"));
+            parameters.AddOptionalParameter("lastFillTime", startTime?.ToString("o"));
 
             var weight = startTime == null ? 2 : 25;
             return await _baseClient.Execute<KrakenFuturesUserTradeResult, IEnumerable<KrakenFuturesUserTrade>>(new Uri(_baseClient.BaseAddress.AppendPath("derivatives/api/v3/fills")), HttpMethod.Get, ct, parameters, signed: true, weight: weight).ConfigureAwait(false);


### PR DESCRIPTION
ToString("u") does not include milliseconds into converting timestamp format. Given that endpoint returns only 100 trades per request currently it is immposiible to receive more than 100 trades from 1 second interval

ToString("u") -> "2009-06-15 13:45:30Z"
ToString("o") -> "2009-06-15T13:45:30.0000000Z"

[endpoint docs](https://docs.futures.kraken.com/#http-api-trading-v3-api-historical-data-get-your-fills)
