### PR TITLE
Cursor loading for deposits and withdrawals

### DIFF
--- a/Kraken.Net.UnitTests/KrakenRestIntegrationTests.cs
+++ b/Kraken.Net.UnitTests/KrakenRestIntegrationTests.cs
@@ -57,8 +57,11 @@ namespace Kraken.Net.UnitTests
             await RunAndCheckResult(client => client.SpotApi.Account.GetTradeVolumeAsync(default, default, default), true);
             await RunAndCheckResult(client => client.SpotApi.Account.GetDepositMethodsAsync("ETH", default, default), true);
             await RunAndCheckResult(client => client.SpotApi.Account.GetDepositStatusAsync(default, default, default, default), true);
+            await RunAndCheckResult(client => client.SpotApi.Account.GetDepositStatusByCursorAsync(default, default, default), true);
             await RunAndCheckResult(client => client.SpotApi.Account.GetWithdrawAddressesAsync(default, default, default, default, default, default), true);
             await RunAndCheckResult(client => client.SpotApi.Account.GetWithdrawMethodsAsync(default, default, default, default), true);
+            await RunAndCheckResult(client => client.SpotApi.Account.GetWithdrawalStatusAsync(default, default, default, default), true);
+            await RunAndCheckResult(client => client.SpotApi.Account.GetWithdrawalStatusByCursorAsync(default, default, default), true);
         }
 
         [Test]

--- a/Kraken.Net/Clients/SpotApi/KrakenRestClientSpotApiAccount.cs
+++ b/Kraken.Net/Clients/SpotApi/KrakenRestClientSpotApiAccount.cs
@@ -166,6 +166,16 @@ namespace Kraken.Net.Clients.SpotApi
         }
 
         /// <inheritdoc />
+        public async Task<WebCallResult<KrakenDepositsStatusCursor>> GetDepositStatusByCursorAsync(string? cursor = null, int? limit = null, CancellationToken ct = default)
+        {
+            var parameters = new Dictionary<string, object>();
+            parameters.AddOptionalParameter("cursor", cursor);
+            parameters.AddOptionalParameter("limit", limit);
+
+            return await _baseClient.Execute<KrakenDepositsStatusCursor>(_baseClient.GetUri("0/private/DepositStatus"), HttpMethod.Post, ct, parameters, true).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
         public async Task<WebCallResult<KrakenWithdrawInfo>> GetWithdrawInfoAsync(string asset, string key, decimal quantity, string? twoFactorPassword = null, CancellationToken ct = default)
         {
             asset.ValidateNotNull(nameof(asset));
@@ -231,6 +241,16 @@ namespace Kraken.Net.Clients.SpotApi
             parameters.AddOptionalParameter("otp", twoFactorPassword ?? _baseClient.ClientOptions.StaticTwoFactorAuthenticationPassword);
 
             return await _baseClient.Execute<IEnumerable<KrakenMovementStatus>>(_baseClient.GetUri("0/private/WithdrawStatus"), HttpMethod.Post, ct, parameters, true).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task<WebCallResult<KrakenWithdrawalsStatusCursor>> GetWithdrawalStatusByCursorAsync(string? cursor = null, int? limit = null, CancellationToken ct = default)
+        {
+            var parameters = new Dictionary<string, object>();
+            parameters.AddOptionalParameter("cursor", cursor);
+            parameters.AddOptionalParameter("limit", limit);
+
+            return await _baseClient.Execute<KrakenWithdrawalsStatusCursor>(_baseClient.GetUri("0/private/WithdrawStatus"), HttpMethod.Post, ct, parameters, true).ConfigureAwait(false);
         }
 
         /// <inheritdoc />

--- a/Kraken.Net/Interfaces/Clients/SpotApi/IKrakenRestClientSpotApiAccount.cs
+++ b/Kraken.Net/Interfaces/Clients/SpotApi/IKrakenRestClientSpotApiAccount.cs
@@ -122,6 +122,16 @@ namespace Kraken.Net.Interfaces.Clients.SpotApi
         Task<WebCallResult<IEnumerable<KrakenMovementStatus>>> GetDepositStatusAsync(string? asset = null, string? depositMethod = null, string? twoFactorPassword = null, CancellationToken ct = default);
 
         /// <summary>
+        /// Get status of deposits by cursor loading
+        /// <para><a href="https://docs.kraken.com/rest/#operation/getStatusRecentDeposits" /></para>
+        /// </summary>
+        /// <param name="cursor">Pass "true" to activate or next cursor link</param>
+        /// <param name="limit">Batch size</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Deposit status list</returns>
+        Task<WebCallResult<KrakenDepositsStatusCursor>> GetDepositStatusByCursorAsync(string? cursor = null, int? limit = null, CancellationToken ct = default);
+
+        /// <summary>
         /// Retrieve fee information about potential withdrawals for a particular asset, key and amount.
         /// <para><a href="https://docs.kraken.com/rest/#operation/getWithdrawalInformation" /></para>
         /// </summary>
@@ -189,6 +199,16 @@ namespace Kraken.Net.Interfaces.Clients.SpotApi
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
         Task<WebCallResult<IEnumerable<KrakenMovementStatus>>> GetWithdrawalStatusAsync(string? asset = null, string? withdrawalMethod = null, string? twoFactorPassword = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Get status of withdrawals by cursor loading
+        /// <para><a href="https://docs.kraken.com/rest/#tag/User-Funding/operation/getStatusRecentWithdrawals" /></para>
+        /// </summary>
+        /// <param name="cursor">Pass "true" to activate or next cursor link</param>
+        /// <param name="limit">Batch size</param>        
+        /// <param name="ct">Cancellation token</param>
+        /// <returns></returns>
+        Task<WebCallResult<KrakenWithdrawalsStatusCursor>> GetWithdrawalStatusByCursorAsync(string? cursor = null, int? limit = null, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel an active withdrawal

--- a/Kraken.Net/Kraken.Net.xml
+++ b/Kraken.Net/Kraken.Net.xml
@@ -367,6 +367,9 @@
         <member name="M:Kraken.Net.Clients.SpotApi.KrakenRestClientSpotApiAccount.GetDepositStatusAsync(System.String,System.String,System.String,System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
+        <member name="M:Kraken.Net.Clients.SpotApi.KrakenRestClientSpotApiAccount.GetDepositStatusByCursorAsync(System.String,System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
         <member name="M:Kraken.Net.Clients.SpotApi.KrakenRestClientSpotApiAccount.GetWithdrawInfoAsync(System.String,System.String,System.Decimal,System.String,System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
@@ -380,6 +383,9 @@
             <inheritdoc />
         </member>
         <member name="M:Kraken.Net.Clients.SpotApi.KrakenRestClientSpotApiAccount.GetWithdrawalStatusAsync(System.String,System.String,System.String,System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
+        <member name="M:Kraken.Net.Clients.SpotApi.KrakenRestClientSpotApiAccount.GetWithdrawalStatusByCursorAsync(System.String,System.Nullable{System.Int32},System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
         <member name="M:Kraken.Net.Clients.SpotApi.KrakenRestClientSpotApiAccount.CancelWithdrawalAsync(System.String,System.String,System.String,System.Threading.CancellationToken)">
@@ -2317,6 +2323,16 @@
             <param name="ct">Cancellation token</param>
             <returns>Deposit status list</returns>
         </member>
+        <member name="M:Kraken.Net.Interfaces.Clients.SpotApi.IKrakenRestClientSpotApiAccount.GetDepositStatusByCursorAsync(System.String,System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Get status of deposits by cursor loading
+            <para><a href="https://docs.kraken.com/rest/#operation/getStatusRecentDeposits" /></para>
+            </summary>
+            <param name="cursor">Pass "true" to activate or next cursor link</param>
+            <param name="limit">Batch size</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Deposit status list</returns>
+        </member>
         <member name="M:Kraken.Net.Interfaces.Clients.SpotApi.IKrakenRestClientSpotApiAccount.GetWithdrawInfoAsync(System.String,System.String,System.Decimal,System.String,System.Threading.CancellationToken)">
             <summary>
             Retrieve fee information about potential withdrawals for a particular asset, key and amount.
@@ -2382,6 +2398,16 @@
             <param name="asset">Filter by asset, for example `ETH`</param>
             <param name="withdrawalMethod">Filter by method</param>
             <param name="twoFactorPassword">Password or authentication app code if enabled</param>
+            <param name="ct">Cancellation token</param>
+            <returns></returns>
+        </member>
+        <member name="M:Kraken.Net.Interfaces.Clients.SpotApi.IKrakenRestClientSpotApiAccount.GetWithdrawalStatusByCursorAsync(System.String,System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Get status of withdrawals by cursor loading
+            <para><a href="https://docs.kraken.com/rest/#tag/User-Funding/operation/getStatusRecentWithdrawals" /></para>
+            </summary>
+            <param name="cursor">Pass "true" to activate or next cursor link</param>
+            <param name="limit">Batch size</param>        
             <param name="ct">Cancellation token</param>
             <returns></returns>
         </member>
@@ -5240,6 +5266,11 @@
             Minimum deposit amount
             </summary>
         </member>
+        <member name="T:Kraken.Net.Objects.Models.KrakenDepositsStatusCursor">
+            <summary>
+            Deposits status info with cursor
+            </summary>
+        </member>
         <member name="T:Kraken.Net.Objects.Models.KrakenEarnStatus">
             <summary>
             Earn status
@@ -6996,6 +7027,11 @@
         <member name="P:Kraken.Net.Objects.Models.KrakenWithdrawAddress.Verified">
             <summary>
             Verified indicator
+            </summary>
+        </member>
+        <member name="T:Kraken.Net.Objects.Models.KrakenWithdrawalsStatusCursor">
+            <summary>
+            Withdrawals status info with cursor
             </summary>
         </member>
         <member name="T:Kraken.Net.Objects.Models.KrakenWithdrawInfo">

--- a/Kraken.Net/Objects/Models/KrakenDepositsStatusCursor.cs
+++ b/Kraken.Net/Objects/Models/KrakenDepositsStatusCursor.cs
@@ -1,0 +1,14 @@
+﻿namespace Kraken.Net.Objects.Models
+{
+    /// <summary>
+    /// Deposits status info with cursor
+    /// </summary>
+    public record KrakenDepositsStatusCursor 
+    {
+        [JsonProperty("deposits")]
+        public IEnumerable<KrakenMovementStatus>? Deposits {  get; set; }
+
+        [JsonProperty("next_cursor")]
+        public string? NextCursor { get; set; }
+    }
+}

--- a/Kraken.Net/Objects/Models/KrakenWithdrawalsStatusCursor.cs
+++ b/Kraken.Net/Objects/Models/KrakenWithdrawalsStatusCursor.cs
@@ -1,0 +1,14 @@
+﻿namespace Kraken.Net.Objects.Models
+{
+    /// <summary>
+    /// Withdrawals status info with cursor
+    /// </summary>
+    public record KrakenWithdrawalsStatusCursor
+    {
+        [JsonProperty("withdrawals")]
+        public IEnumerable<KrakenMovementStatus>? Withdrawals { get; set; }
+
+        [JsonProperty("next_cursor")]
+        public string? NextCursor { get; set; }
+    }
+}


### PR DESCRIPTION
Issue 
- no full parameters supprort for private/WithdrawStatus and private/DepositStatus endpoints leading to no ability to load more than default 'limit' number of records

Implemented 
- Added a separate methods to load deposit statuses and withdrawal statuses by cursor loading. It is because the returning json has a different json scema so it seems immposible to me to implement that in the existing methods

docs:
https://docs.kraken.com/api/docs/rest-api/get-status-recent-deposits
https://docs.kraken.com/api/docs/rest-api/get-status-recent-withdrawals