### PR TITLE
Fix incorrect values for OneWeek and FifteenDays in KlineInterval enum

### DIFF
--- a/Kraken.Net/Enums/KlineInterval.cs
+++ b/Kraken.Net/Enums/KlineInterval.cs
@@ -46,11 +46,11 @@ namespace Kraken.Net.Enums
         /// 1w
         /// </summary>
         [Map("10080")]
-        OneWeek = 60 * 60 * 7,
+        OneWeek = 60 * 60 * 24 * 7,
         /// <summary>
         /// 15d
         /// </summary>
         [Map("21600")]
-        FifteenDays = 60 * 60 * 15
+        FifteenDays = 60 * 60 * 24 * 15
     }
 }


### PR DESCRIPTION
This pull request fixes incorrect values for `OneWeek` and `FifteenDays` in the `KlineInterval` enum.

- `OneWeek` was incorrectly set to 7 hours (25200 seconds). Corrected to 7 days (604800 seconds).
- `FifteenDays` was incorrectly set to 15 hours (54000 seconds). Corrected to 15 days (1296000 seconds).