### PR TITLE
Fixed nonce replacement when retrying authenticated requests

### DIFF
--- a/Kraken.Net.UnitTests/KrakenClientTests.cs
+++ b/Kraken.Net.UnitTests/KrakenClientTests.cs
@@ -13,8 +13,10 @@ using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using CryptoExchange.Net.Objects;
+using CryptoExchange.Net.Interfaces;
 using Kraken.Net.Interfaces.Clients;
 using Kraken.Net.Clients.SpotApi;
+using Moq;
 
 namespace Kraken.Net.UnitTests
 {
@@ -48,6 +50,38 @@ namespace Kraken.Net.UnitTests
                     { "type", "buy" },
                     { "volume", "1.25" },
                 });
+        }
+
+        [Test]
+        public void ProcessRequest_ReusedParameters_ReplacesNonce()
+        {
+            var nonceProvider = new Mock<INonceProvider>();
+            nonceProvider.SetupSequence(x => x.GetNonce())
+                .Returns(1)
+                .Returns(2);
+            var authProvider = new KrakenAuthenticationProvider(
+                new KrakenCredentials().WithSpot("key", "kQH5HW/8p1uGOVjbgWA7FunAmGO8lsSUXNsu3eow76sz84Q18fWxnyRzBHCd3pd5nE9qa99HAZtuZuj6F1huXg=="),
+                nonceProvider.Object);
+            var client = (RestApiClient)new KrakenRestClient().SpotApi;
+            var parameters = new Parameters(KrakenExchange._parameterSerializationSettings);
+            var requestDefinition = new RequestDefinition("https://api.kraken.com", "/0/private/QueryOrders", HttpMethod.Post)
+            {
+                Authenticated = true
+            };
+
+            RestRequestConfiguration CreateRequest() => new(
+                requestDefinition,
+                null,
+                parameters,
+                new Dictionary<string, string>(),
+                HttpMethodParameterPosition.InBody,
+                RequestBodyFormat.FormData);
+
+            authProvider.ProcessRequest(client, CreateRequest());
+
+            Assert.That(parameters["nonce"], Is.EqualTo(1));
+            Assert.DoesNotThrow(() => authProvider.ProcessRequest(client, CreateRequest()));
+            Assert.That(parameters["nonce"], Is.EqualTo(2));
         }
 
         [Test]

--- a/Kraken.Net/KrakenAuthenticationProvider.cs
+++ b/Kraken.Net/KrakenAuthenticationProvider.cs
@@ -34,7 +34,9 @@ namespace Kraken.Net
             request.Headers.Add("API-Key", Credential.Key);
             var nonce = _nonceProvider.GetNonce();
             var parameters = request.GetPositionParameters();
-            parameters.Add("nonce", nonce);
+            
+            // Add or replace the nonce to ensure it is overwritten when parameters are reused for retries.
+            parameters["nonce"] = nonce;
 
             var body = request.ParameterPosition == HttpMethodParameterPosition.InUri ? string.Empty : request.BodyFormat == RequestBodyFormat.Json ? GetSerializedBody(_serializer, parameters) : (request.BodyParameters?.ToFormData() ?? string.Empty);
             var queryString = request.GetQueryString();


### PR DESCRIPTION
Fixed authenticated request retries failing when the request parameters already contain a nonce.

When an authenticated request is retried, the existing request parameters can be reused. `KrakenAuthenticationProvider.ProcessRequest` previously added the new nonce using `Parameters.Add`.

Because the previous nonce was still present, the retry failed before being sent:

```log
Error while sending request
 ---> System.Exception: Failed to authenticate request, make sure your API credentials are correct
 ---> System.ArgumentException: An item with the same key has already been added. Key: [nonce, 654321432104811123]
   at System.Collections.Generic.SortedDictionary`2.Add(TKey key, TValue value)
   at Kraken.Net.KrakenAuthenticationProvider.ProcessRequest(RestApiClient apiClient, RestRequestConfiguration request) in /_/Kraken.Net/KrakenAuthenticationProvider.cs:line 30
   at CryptoExchange.Net.Clients.RestApiClient.CreateRequest(Int32 requestId, RequestDefinition definition, Parameters uriParameters, Parameters bodyParameters, Dictionary`2 additionalHeaders) in /_/CryptoExchange.Net/Clients/RestApiClient.cs:line 353
   --- End of inner exception stack trace ---
   at CryptoExchange.Net.Clients.RestApiClient.CreateRequest(Int32 requestId, RequestDefinition definition, Parameters uriParameters, Parameters bodyParameters, Dictionary`2 additionalHeaders) in /_/CryptoExchange.Net/Clients/RestApiClient.cs:line 367
   at CryptoExchange.Net.Clients.RestApiClient.SendAsync[T](RequestDefinition definition, Parameters uriParameters, Parameters bodyParameters, CancellationToken cancellationToken, Dictionary`2 additionalHeaders, Nullable`1 weight, Nullable`1 weightSingleLimiter, String rateLimitKeySuffix) in /_/CryptoExchange.Net/Clients/RestApiClient.cs:line 231
   at Kraken.Net.Clients.SpotApi.KrakenRestClientSpotApi.SendAsync[T](RequestDefinition definition, Parameters parameters, CancellationToken cancellationToken, Nullable`1 weight)
   at Kraken.Net.Clients.SpotApi.KrakenRestClientSpotApiTrading.GetOrdersAsync(IEnumerable`1 orderIds, Nullable`1 clientOrderId, Nullable`1 consolidateTaker, Nullable`1 trades, String twoFactorPassword, CancellationToken ct) in /_/Kraken.Net/Clients/SpotApi/KrakenRestClientSpotApiTrading.cs:line 100
...
```