### PR TITLE
Shared asset types

### DIFF
--- a/Kraken.Net/Clients/FuturesApi/KrakenRestClientFuturesApiShared.cs
+++ b/Kraken.Net/Clients/FuturesApi/KrakenRestClientFuturesApiShared.cs
@@ -196,7 +196,7 @@ namespace Kraken.Net.Clients.FuturesApi
 
         #region Futures Symbol client
 
-        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicId, EnvironmentName, null);
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {

--- a/Kraken.Net/Clients/FuturesApi/KrakenRestClientFuturesApiShared.cs
+++ b/Kraken.Net/Clients/FuturesApi/KrakenRestClientFuturesApiShared.cs
@@ -196,6 +196,7 @@ namespace Kraken.Net.Clients.FuturesApi
 
         #region Futures Symbol client
 
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
@@ -207,36 +208,40 @@ namespace Kraken.Net.Clients.FuturesApi
             if (!result.Success)
                 return HttpResult.Fail<SharedFuturesSymbol[]>(result);
 
-            var data = result.Data.Where(x => x.Type != Enums.SymbolType.SpotIndex && !x.Symbol.StartsWith("rr"));
-            var resultData = data.Select(s =>
+            var data = result.Data
+               .Where(x => x.Type != Enums.SymbolType.SpotIndex && !x.Symbol.StartsWith("rr"))
+               .Select(x => ParseSymbol(x))
+               .ToArray();
+
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, data);
+            return HttpResult.Ok(result, SharedUtils.ApplySymbolFilter(data, request));
+        }
+
+        private SharedFuturesSymbol ParseSymbol(KrakenFuturesSymbol s)
+        {
+            var split = s.Symbol.Split('_');
+            var assets = split[1];
+
+            var result = new SharedFuturesSymbol(
+                s.Type == Enums.SymbolType.FlexibleFutures && split.Count() == 2 ? TradingMode.PerpetualLinear :
+                s.Type == Enums.SymbolType.FlexibleFutures && split.Count() > 2 ? TradingMode.DeliveryLinear :
+                s.Type == Enums.SymbolType.InverseFutures && split.Count() == 2 ? TradingMode.PerpetualInverse :
+                TradingMode.DeliveryInverse,
+                s.BaseAsset,
+                s.QuoteAsset,
+                s.Symbol,
+                s.Tradeable)
             {
-                var split = s.Symbol.Split('_');
-                var assets = split[1];
+                QuantityDecimals = (int?)s.ContractValueTradePrecision,
+                PriceStep = s.TickSize,
+                ContractSize = s.ContractSize,
+                DeliveryTime = split.Count() > 2 ? DateTime.ParseExact(split[2], "yyMMdd", CultureInfo.InvariantCulture) : null,
+                DisplayName = s.Symbol,
+                QuoteAssetType = SharedAssetType.Fiat,
+                BaseAssetType = SharedAssetType.Crypto
+            };
 
-                return new SharedFuturesSymbol(
-                    s.Type == Enums.SymbolType.FlexibleFutures && split.Count() == 2 ? TradingMode.PerpetualLinear :
-                    s.Type == Enums.SymbolType.FlexibleFutures && split.Count() > 2 ? TradingMode.DeliveryLinear :
-                    s.Type == Enums.SymbolType.InverseFutures && split.Count() == 2 ? TradingMode.PerpetualInverse :
-                    TradingMode.DeliveryInverse,
-                    s.BaseAsset,
-                    s.QuoteAsset,
-                    s.Symbol,
-                    s.Tradeable)
-                {
-                    QuantityDecimals = (int?)s.ContractValueTradePrecision,
-                    PriceStep = s.TickSize,
-                    ContractSize = s.ContractSize,
-                    DeliveryTime = split.Count() > 2 ? DateTime.ParseExact(split[2], "yyMMdd", CultureInfo.InvariantCulture) : null
-                };
-            });
-
-            if (request.TradingMode != null)
-                resultData = resultData.Where(x => request.TradingMode == x.TradingMode);
-
-            var response = HttpResult.Ok(result, resultData.ToArray());
-            
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, response.Data!);
-            return response;
+            return result;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)

--- a/Kraken.Net/Clients/SpotApi/KrakenRestClientSpotApiShared.cs
+++ b/Kraken.Net/Clients/SpotApi/KrakenRestClientSpotApiShared.cs
@@ -88,7 +88,7 @@ namespace Kraken.Net.Clients.SpotApi
 
         #region Spot Symbol client
 
-        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicId, EnvironmentName, null);
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false)
         {
             OptionalExchangeParameters = [            

--- a/Kraken.Net/Clients/SpotApi/KrakenRestClientSpotApiShared.cs
+++ b/Kraken.Net/Clients/SpotApi/KrakenRestClientSpotApiShared.cs
@@ -18,6 +18,8 @@ namespace Kraken.Net.Clients.SpotApi
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
         public SharedClientInfo Discover() => SharedUtils.GetClientInfo(KrakenExchange.Metadata, this);
 
+        private static readonly HashSet<string> _exchangeFiat = ["USD", "EUR", "GBP", "CHF", "AUD", "CAD", "JPY"];
+
         #region Kline client
 
         GetKlinesOptions IKlineRestClient.GetKlinesOptions { get; } = new GetKlinesOptions(_exchangeName, true, false, true, 720, false,
@@ -86,6 +88,7 @@ namespace Kraken.Net.Clients.SpotApi
 
         #region Spot Symbol client
 
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false)
         {
             OptionalExchangeParameters = [            
@@ -99,31 +102,70 @@ namespace Kraken.Net.Clients.SpotApi
                 return HttpResult.Fail<SharedSpotSymbol[]>(Exchange, validationError);
 
             var useNewAssetResponse = request.GetParamValue<bool?>(Exchange, "NewAssetNames", "assetVersion");
-            var result = await ExchangeData.GetSymbolsAsync(newAssetNameResponse: useNewAssetResponse, ct: ct).ConfigureAwait(false);
-            if (!result.Success)
-                return HttpResult.Fail<SharedSpotSymbol[]>(result);
+            var currencyTask = ExchangeData.GetSymbolsAsync(newAssetNameResponse: useNewAssetResponse, aClass: AClass.Currency, ct: ct);
+            var tokenTask = ExchangeData.GetSymbolsAsync(newAssetNameResponse: useNewAssetResponse, aClass: AClass.TokenizedAsset, ct: ct);
+            await Task.WhenAll(currencyTask, tokenTask).ConfigureAwait(false);
+            var currencyResult = currencyTask.Result;
+            var tokenResult = tokenTask.Result;
+            if (!currencyResult.Success)
+                return HttpResult.Fail<SharedSpotSymbol[]>(currencyResult);
+            if (!tokenResult.Success)
+                return HttpResult.Fail<SharedSpotSymbol[]>(tokenResult);
 
-            var response = HttpResult.Ok(result, result.Data.Select(s =>
+            var currencyResultData = currencyResult.Data
+               .Select(x => ParseSymbol(x, false));
+            var tokenResultData = tokenResult.Data.Where(x => !x.Key.EndsWith("SPVUSD"))
+               .Select(x => ParseSymbol(x, true));
+            var resultData = currencyResultData.Concat(tokenResultData)
+               .ToArray();
+
+            // Also register [BaseAsset]/[QuoteAsset] and [BaseAsset][QuoteAsset] as names
+            var symbolRegistrations = resultData
+                .Concat(resultData.Select(x => new SharedSpotSymbol(x.BaseAsset, x.QuoteAsset, x.BaseAsset + "/" + x.QuoteAsset, x.Trading, x.TradingMode)))
+                .Concat(resultData.Where(x => x.Name != x.BaseAsset + x.QuoteAsset).Select(x => new SharedSpotSymbol(x.BaseAsset, x.QuoteAsset, x.BaseAsset + x.QuoteAsset, x.Trading, x.TradingMode)))
+                .ToArray();
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, symbolRegistrations);
+            return HttpResult.Ok(currencyResult, SharedUtils.ApplySymbolFilter(resultData, request));
+        }
+
+        private SharedSpotSymbol ParseSymbol(KeyValuePair<string, KrakenSymbol> s, bool isTokenized)
+        {
+            var assets = GetAssets(s.Value.WebsocketName);
+            var result = new SharedSpotSymbol(assets.BaseAsset, assets.QuoteAsset, s.Key, s.Value.Status == SymbolStatus.Online)
             {
-                var assets = GetAssets(s.Value.WebsocketName);
-                return new SharedSpotSymbol(assets.BaseAsset, assets.QuoteAsset, s.Key, s.Value.Status == SymbolStatus.Online)
-                {
-                    PriceDecimals = s.Value.PriceDecimals,
-                    QuantityDecimals = s.Value.LotDecimals,
-                    MinTradeQuantity = s.Value.OrderMin,
-                    PriceStep = s.Value.TickSize,
-                    MinNotionalValue = s.Value.MinValue
-                };
-            }).ToArray());
+                PriceDecimals = s.Value.PriceDecimals,
+                QuantityDecimals = s.Value.LotDecimals,
+                MinTradeQuantity = s.Value.OrderMin,
+                PriceStep = s.Value.TickSize,
+                MinNotionalValue = s.Value.MinValue,
+                BaseAssetType = isTokenized ? SharedAssetType.TradFi : SharedAssetType.Crypto
+            };
 
-            // Also register [BaseAsset]/[QuoteAsset] as names for websocket and [BaseAsset][QuoteAsset]
-            var symbolRegistrations = response.Data!
-                .Concat(response.Data!.Select(x => new SharedSpotSymbol(x.BaseAsset, x.QuoteAsset, x.BaseAsset + "/" + x.QuoteAsset, x.Trading, x.TradingMode))).ToList();
-            foreach (var symbol in response.Data!.Where(x => x.Name != x.BaseAsset + x.QuoteAsset))
-                symbolRegistrations.Add(new SharedSpotSymbol(symbol.BaseAsset, symbol.QuoteAsset, symbol.BaseAsset + symbol.QuoteAsset, symbol.Trading));
+            if (LibraryHelpers.IsStableCoin(result.QuoteAsset))
+            {
+                result.QuoteAssetType = SharedAssetType.Crypto;
+                result.QuoteAssetSubType = SharedAssetSubType.StableCoin;
+            }
+            else if (_exchangeFiat.Contains(result.QuoteAsset))
+            {
+                result.QuoteAssetType = SharedAssetType.Fiat;
+            }
+            else
+            {
+                result.QuoteAssetType = SharedAssetType.Crypto;
+            }
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, symbolRegistrations.ToArray());
-            return response;
+            if (isTokenized)
+            {
+                result.BaseAssetSubType = SharedAssetSubType.Equity;
+            }
+            else
+            {
+                if (LibraryHelpers.IsStableCoin(result.BaseAsset))
+                    result.BaseAssetSubType = SharedAssetSubType.StableCoin;
+            }
+
+            return result;
         }
 
         private (string BaseAsset, string QuoteAsset) GetAssets(string name)

--- a/Kraken.Net/Clients/SpotApi/KrakenRestClientSpotApiShared.cs
+++ b/Kraken.Net/Clients/SpotApi/KrakenRestClientSpotApiShared.cs
@@ -138,6 +138,7 @@ namespace Kraken.Net.Clients.SpotApi
                 MinTradeQuantity = s.Value.OrderMin,
                 PriceStep = s.Value.TickSize,
                 MinNotionalValue = s.Value.MinValue,
+                DisplayName = s.Key,
                 BaseAssetType = isTokenized ? SharedAssetType.TradFi : SharedAssetType.Crypto
             };
 

--- a/Kraken.Net/Kraken.Net.csproj
+++ b/Kraken.Net/Kraken.Net.csproj
@@ -56,12 +56,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="CryptoExchange.Net" Version="12.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/Kraken.Net/Kraken.Net.csproj
+++ b/Kraken.Net/Kraken.Net.csproj
@@ -56,10 +56,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="CryptoExchange.Net" Version="12.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updated CryptoExchange.Net to v12.2.0 
Added SpotSymbolCatalog to Shared ISpotSymbolRestClient interface
Added FuturesSymbolCatalog to Shared IFuturesSymbolRestClient interface
Added BaseAssetType, BaseAssetSubType, QuoteAssetType and QuoteAssetSubType to GetSymbolsRequest model
Added DisplayName to SharedSpotSymbol and SharedFuturesSymbol models
Added BaseAssetType, BaseAssetSubType, QuoteAssetType and QuoteAssetSubType to SharedSpotSymbol and SharedFuturesSymbol models
Added DebuggerDisplay attributes to Shared models